### PR TITLE
Bug fix photo uploads

### DIFF
--- a/app/uploaders/profile_photo_uploader.rb
+++ b/app/uploaders/profile_photo_uploader.rb
@@ -16,12 +16,13 @@ class ProfilePhotoUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  # # Provide a default URL as a default if there hasn't been a file uploaded:
-  # def default_url(*args)
-  #   # For Rails 3.1+ asset pipeline compatibility:
-  #   ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
-  #
-  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*)
+  #   # # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #   #
+  #   # "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  #   "https://toy-exchange-development.s3.amazonaws.com/defaults/default.jpg"
   # end
 
   # Process files as they are uploaded:
@@ -33,10 +34,16 @@ class ProfilePhotoUploader < CarrierWave::Uploader::Base
   # Create different versions of your uploaded files:
   version :avatar do
     process resize_to_fit: [64, 64]
+    def default_url
+      "https://toy-exchange-development.s3.amazonaws.com/defaults/avatar_default.jpg"
+    end
   end
 
   version :profile do
     process resize_to_fit: [256, 340]
+    def default_url
+      "https://toy-exchange-development.s3.amazonaws.com/defaults/profile_default.jpg"
+    end
   end
 
   # Add a white list of extensions which are allowed to be uploaded.

--- a/app/uploaders/toy_photo_uploader.rb
+++ b/app/uploaders/toy_photo_uploader.rb
@@ -45,9 +45,9 @@ class ToyPhotoUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/uploaders/toy_photo_uploader.rb
+++ b/app/uploaders/toy_photo_uploader.rb
@@ -37,10 +37,16 @@ class ToyPhotoUploader < CarrierWave::Uploader::Base
   # end
   version :thumb do
     process resize_to_fit: [225, 225]
+    def default_url
+      "https://toy-exchange-development.s3.amazonaws.com/defaults/thumb_toy_default.jpg"
+    end
   end
 
   version :hero do
     process resize_to_fit: [350, 350]
+    def default_url
+      "https://toy-exchange-development.s3.amazonaws.com/defaults/hero_toy_default.jpg"
+    end
   end
 
   # Add a white list of extensions which are allowed to be uploaded.


### PR DESCRIPTION
# Fix Photo Upload Defaults

## PR Summary

This PR accomplishes the following:
- Adds default links for versions of profile, toy photos

## Next Actions

- Add Google maps/geolocation apis
- Styling updates
- Devise auth
- General cleanup

## Additional Notes
This fix jumped the queue due to breaking the site when creating a new account, especially on Heroku, when trying to render the header after registration, which would contain the new user avatar-sized image.